### PR TITLE
Expose sections

### DIFF
--- a/components.js
+++ b/components.js
@@ -94,6 +94,35 @@ export const Modal = window.components.Modal;
  export const Overlay = window.components.Overlay || NotCompatible('5.0');
 
  /**
+ * Section component.
+ *
+ * @type {import('react').ComponentType<{ maxHeight: Number | String, relativePos: Boolean } }>}
+ *
+ * @example
+ * 
+ * import { Section } from 'camunda-modeler-plugin-helpers/components';
+ *
+ * function CustomSection(props) {
+ *   return (
+ *    <Section maxHeight="240px">
+ *     <Section.Header>
+ *       Custom section
+ *     </Section.Header>
+ *     <Section.Body>
+ *       Hello world!
+ *     </Section.Body>
+ *     <Section.Actions>
+ *      <button type="button" onClick={ props.onClose }>
+ *        Close
+ *      </button>
+ *     </Section.Actions>
+ *    </Section>
+ *   );
+ * }
+ */
+export const Section = window.components.Section || NotCompatible('5.0');
+
+ /**
  * ToggleSwitch component.
  *
  * @type {import('react').ComponentType<{ id: string, name: string, label?: string, switcherLabel?: string, description?: string }>}

--- a/components.js
+++ b/components.js
@@ -91,7 +91,7 @@ export const Modal = window.components.Modal;
  *   );
  * }
  */
- export const Overlay = window.components.Overlay || NotCompatible('4.12');
+ export const Overlay = window.components.Overlay || NotCompatible('5.0');
 
  /**
  * ToggleSwitch component.
@@ -120,4 +120,4 @@ export const Modal = window.components.Modal;
  *   );
  * }
  */
-export const ToggleSwitch = window.components.ToggleSwitch || NotCompatible('4.12');
+export const ToggleSwitch = window.components.ToggleSwitch || NotCompatible('5.0');

--- a/components.js
+++ b/components.js
@@ -67,7 +67,15 @@ export const Modal = window.components.Modal;
 /**
  * Overlay component.
  *
- * @type {import('react').ComponentType<{ onClose: Function, anchor: Node, offset?: { bottom?: number, left?: number, right?: number } }>}
+ * @type {import('react').ComponentType<{ 
+ *  onClose: Function, 
+ *  anchor: Node, 
+ *  offset?: { top?: number, bottom?: number, left?: number, right?: number }, 
+ *  maxWidth?: number | string,
+ *  maxHeight?: number | string,
+ *  minWidth?: number | string,
+ *  minHeight?: number | string
+ * }>}
  *
  * @example
  * 


### PR DESCRIPTION
This exposes our new section components to plugins. It also marks the toggle switch and overlays as `5.0` compatible, since we won't expose them with the `4.12` release.

Related to https://github.com/camunda/camunda-modeler/pull/2628