### PR TITLE
Expose vendor deps

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -1,0 +1,12 @@
+module.exports.returnOrThrow = function(getter, minimalModelerVersion) {
+  let result;
+  try {
+    result = getter();
+  } catch (error) {}
+
+  if (!result) {
+    throw new Error(`Not compatible with Camunda Modeler < ${minimalModelerVersion}`);
+  }
+
+  return result;
+}

--- a/vendor/@bpmn-io/properties-panel/index.js
+++ b/vendor/@bpmn-io/properties-panel/index.js
@@ -1,0 +1,3 @@
+const { returnOrThrow } = require('../../../helper');
+
+module.exports = returnOrThrow(() => window.propertiesPanel.common, '5.0.0');

--- a/vendor/@bpmn-io/properties-panel/preact/compat.js
+++ b/vendor/@bpmn-io/properties-panel/preact/compat.js
@@ -1,0 +1,3 @@
+const { returnOrThrow } = require('../../../../helper');
+
+module.exports = returnOrThrow(() => window.propertiesPanel.preact.compat, '5.0.0');

--- a/vendor/@bpmn-io/properties-panel/preact/hooks.js
+++ b/vendor/@bpmn-io/properties-panel/preact/hooks.js
@@ -1,0 +1,3 @@
+const { returnOrThrow } = require('../../../../helper');
+
+module.exports = returnOrThrow(() => window.propertiesPanel.preact.hooks, '5.0.0');

--- a/vendor/@bpmn-io/properties-panel/preact/index.js
+++ b/vendor/@bpmn-io/properties-panel/preact/index.js
@@ -1,0 +1,3 @@
+const { returnOrThrow } = require('../../../../helper');
+
+module.exports = returnOrThrow(() => window.propertiesPanel.preact.root, '5.0.0');

--- a/vendor/@bpmn-io/properties-panel/preact/jsx-runtime.js
+++ b/vendor/@bpmn-io/properties-panel/preact/jsx-runtime.js
@@ -1,0 +1,3 @@
+const { returnOrThrow } = require('../../../../helper');
+
+module.exports = returnOrThrow(() => window.propertiesPanel.preact.jsxRuntime, '5.0.0');

--- a/vendor/bpmn-js-properties-panel.js
+++ b/vendor/bpmn-js-properties-panel.js
@@ -1,0 +1,3 @@
+const { returnOrThrow } = require('../helper');
+
+module.exports = returnOrThrow(() => window.propertiesPanel.bpmn, '5.0.0');

--- a/vendor/react.js
+++ b/vendor/react.js
@@ -1,0 +1,1 @@
+module.exports = require('../react');


### PR DESCRIPTION
Available in Camunda Modeler 5.

Use libraries exposed in Camunda Modeler via /vendor subdirectories:
  * /vendor/@bpmn-io/properties-panel/...
  * /vendor/bpmn-js-properties-panel
  * /vendor/react

In your webpack configuration, set aliases:

```js
// webpack.config.js
{
  resolve: {
    alias: {
      'react': 'camunda-modeler-plugin-helpers/vendor/react',
      '@bpmn-io/properties-panel': 'camunda-modeler-plugin-helpers/vendor/@bpmn-io/properties-panel',
      'bpmn-js-properties-panel': 'camunda-modeler-plugin-helpers/vendor/bpmn-js-properties-panel'
    }
  }
}
```

Then, in the source code of your extension, you can still import:

```js
import { useService } from 'bpmn-js-properties-panel';
import { useState } from '@bpmn-io/properties-panel/preact/hooks';
```