### PR TITLE
feat: expose carbon/react and carbon/icons-react deps

### DIFF
--- a/@carbon/icons-react.js
+++ b/@carbon/icons-react.js
@@ -1,0 +1,10 @@
+if (!window.carbonicons) {
+  throw new Error('Not compatible with Camunda Modeler < v5.33.0');
+}
+
+/**
+ * Use this to access Carbon icons globally in UI extensions.
+ *
+ * @type {import('@carbon/icons-react')}
+ */
+export default window.carbonicons;

--- a/@carbon/react.js
+++ b/@carbon/react.js
@@ -1,0 +1,11 @@
+if (!window.carbon) {
+  throw new Error('Not compatible with Camunda Modeler < v5.33.0');
+}
+
+/**
+ * Carbon React components provided by the host application.
+ * Use this to access Carbon components globally in UI extensions.
+ *
+ * @type {import('@carbon/react')}
+ */
+export default window.carbon;


### PR DESCRIPTION
Related to camunda-modeler: [#4511](https://github.com/camunda/camunda-modeler/issues/4511)
### Proposed Changes

Exposed carbon/react and carbon/icons-react for plugins. 
Plugins can now use carbon using 
```
// example
import { Button, Theme, IconButton, TextInput } from 'camunda-modeler-plugin-helpers/@carbon/react';
import { Add } from 'camunda-modeler-plugin-helpers/@carbon/icons-react';
```
<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
